### PR TITLE
Add calculations for diameter and aspect ratio params in `FieldProcessing` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.0] - 2024-06-10
+
++ Feature - Add diameter and aspect ratio params computation in `FieldProcessing` table
++ Update - all occurrences of `datetime.utcnow()` to `datetime.now(timezone.utc)`.
+
 ## [0.1.0] - 2024-06-06
 
 + Feature - Pull from upstream staging for image processing / segmentation on a per-field basis

--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -291,6 +291,15 @@ class FieldProcessing(dj.Computed):
             from suite2p.run_s2p import run_plane
 
             ops_path = find_full_path(processed_root_data_dir, extra_params["ops_path"])
+
+            # calculate aspect ratio and diameter
+            um_height, um_width = (scan.ScanInfo.Field & key).fetch1(
+                "um_height", "um_width"
+            )
+            aspect = um_height / um_width
+            params["aspect"] = aspect
+            params["diameter"] = round(10 * aspect)
+
             run_plane(params, ops_path=ops_path)
         else:
             raise NotImplementedError(

--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -1,9 +1,6 @@
 import gc
-import importlib
-import inspect
 import pathlib
-from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 
 import datajoint as dj
@@ -80,7 +77,7 @@ class FieldPreprocessing(dj.Computed):
         return ks - imaging.Processing.proj()
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
         processed_root_data_dir = scan.get_processed_root_data_dir()
 
         output_dir = (imaging.ProcessingTask & key).fetch1("processing_output_dir")
@@ -239,7 +236,7 @@ class FieldPreprocessing(dj.Computed):
                 f"Field processing for {acq_software} scans with {method} is not yet supported in this table."
             )
 
-        exec_dur = (datetime.utcnow() - execution_time).total_seconds() / 3600
+        exec_dur = (datetime.now(timezone.utc) - execution_time).total_seconds() / 3600
         self.insert1(
             {
                 **key,
@@ -260,7 +257,7 @@ class FieldProcessing(dj.Computed):
     """
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
         processed_root_data_dir = scan.get_processed_root_data_dir()
 
         output_dir, params = (FieldPreprocessing.Field & key).fetch1(
@@ -304,7 +301,7 @@ class FieldProcessing(dj.Computed):
         # as these may have large memory footprint and may not be cleared fast enough
         gc.collect()
 
-        exec_dur = (datetime.utcnow() - execution_time).total_seconds() / 3600
+        exec_dur = (datetime.now(timezone.utc) - execution_time).total_seconds() / 3600
         self.insert1(
             {
                 **key,
@@ -344,7 +341,7 @@ class FieldPostProcessing(dj.Computed):
         return FieldPreprocessing & per_plane_proc
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
         method, params = (
             imaging.ProcessingTask * imaging.ProcessingParamSet & key
         ).fetch1("processing_method", "params")
@@ -357,7 +354,7 @@ class FieldPostProcessing(dj.Computed):
 
             io.combined(output_dir / "suite2p", save=True)
 
-        exec_dur = (datetime.utcnow() - execution_time).total_seconds() / 3600
+        exec_dur = (datetime.now(timezone.utc) - execution_time).total_seconds() / 3600
         self.insert1(
             {
                 **key,
@@ -368,7 +365,7 @@ class FieldPostProcessing(dj.Computed):
         imaging.Processing.insert1(
             {
                 **key,
-                "processing_time": datetime.utcnow(),
+                "processing_time": datetime.now(timezone.utc),
                 "package_version": "",
             },
             allow_direct_insert=True,

--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -102,7 +102,7 @@ class FieldPreprocessing(dj.Computed):
         ).fetch1("processing_method", "params")
         acq_software = (scan.Scan & key).fetch1("acq_software")
 
-        field_ind = (scan.ScanInfo.Field & key).fetch("field_idx")
+        field_list = (scan.ScanInfo.Field & key).fetch("field_idx")
         sampling_rate, ndepths, nchannels, nfields, nrois = (
             scan.ScanInfo & key
         ).fetch1("fps", "ndepths", "nchannels", "nfields", "nrois")
@@ -123,7 +123,7 @@ class FieldPreprocessing(dj.Computed):
             )
 
             field_processing_tasks = []
-            for field_idx, plane_idx in zip(field_ind, PVmeta.meta["plane_indices"]):
+            for field_idx, plane_idx in zip(field_list, PVmeta.meta["plane_indices"]):
                 pln_output_dir = output_dir / f"pln{plane_idx}_chn{channel}"
                 pln_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -169,7 +169,9 @@ class FieldPreprocessing(dj.Computed):
                 for image_file in image_files
             ]
 
-            scan_ = scanreader.read_scan(image_files)
+            scan_ = scanreader.read_scan(
+                image_files
+            )  # scan_[fields, y, x, channel, frames]
 
             ops = {**default_ops(), **params}
 
@@ -183,6 +185,29 @@ class FieldPreprocessing(dj.Computed):
             ops["tiff_list"] = [f for f in image_files]
             ops["force_sktiff"] = False
 
+            # ops['diameter']:
+            from ScanImageTiffReader import ScanImageTiffReader
+            import json
+
+            reader = ScanImageTiffReader(image_files[0])
+            tiff_dim = reader.shape()
+            h = reader.metadata()
+            js = h.find("{\n")
+            hh = h[1 : js - 2].splitlines()
+            json_obj = json.loads(h[js:-1])
+            si_rois = json_obj["RoiGroups"]["imagingRoiGroup"]["rois"]
+            if type(si_rois) is dict:
+                si_rois = [si_rois]  # scan_
+            # si_rois[n_field] has "zs"=[100,200], and "scanfields"= [dict1, dict2]. zs = si_rois[3]["zs"] # [100,200]
+
+            field_list, roi_list, field_z_list = (scan.ScanInfo.Field & key).fetch(
+                "field_idx", "roi", "field_z"
+            )
+            plane_list = [
+                sorted(set(field_z_list)).index(value) for value in field_z_list
+            ]
+            assert len(roi_list) == len(field_list) == len(plane_list)
+
             ops.update(
                 {
                     "mesoscan": True,
@@ -192,14 +217,40 @@ class FieldPreprocessing(dj.Computed):
                     "dy": [],  # y-offset for each field
                     "slices": [],  # plane index for each field
                     "lines": [],  # row indices for each field
+                    "diameter": [],  # calculated diameter for each field
                 }
             )
+
             for field_idx, field_info in enumerate(scan_.fields):
                 ops["dx"].append(field_info.xslices[0].start)
                 ops["dy"].append(field_info.yslices[0].start)
                 ops["slices"].append(field_info.slice_id)
                 ops["lines"].append(
                     np.arange(field_info.yslices[0].start, field_info.yslices[0].stop)
+                )
+
+            # Per field based on si_rois obj:
+            aspect = []
+            diameters = []
+            for i in np.arange(0, len(plane_list)):  # list of 10 fields
+                zs = 0  # Not sure about this. TO-DO
+                mmPerPix_Y = si_rois[roi_list[i]]["scanfields"][zs][
+                    "pixelToRefTransform"
+                ][1][1]
+                mmPerPix_X = si_rois[roi_list[i]]["scanfields"][zs][
+                    "pixelToRefTransform"
+                ][0][0]
+                aspect.append(np.array(mmPerPix_Y) / np.array(mmPerPix_X))
+                diameters.append([10, round(10 * aspect[i])])
+
+            diameters_unique = np.unique(diameters)
+
+            # assume that the round value is going to be the same in all the fields (25)
+            if len(diameters_unique) == 2:
+                ops["diameter"] = diameters_unique[1]
+            else:
+                raise NotImplementedError(
+                    f"Different diameter values for fields (n={len(diameters_unique)}) with {method} is not yet supported in this table."
                 )
 
             # generate binary files for each field

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,4 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.1.0"
-
+__version__ = "0.2.0"


### PR DESCRIPTION
- [x] Add diameter and aspect ratio params computation in `FieldProcessing` table
- [x] Update all occurrences of `datetime.utcnow()` to `datetime.now(timezone.utc)` due to the deprecation of `utcnow()`.
- [x] Local testing by importing the pipeline and populating up to `field_processing.FieldPreprocessing` (included).